### PR TITLE
Enable Camera2 API

### DIFF
--- a/common/system.prop
+++ b/common/system.prop
@@ -1,3 +1,4 @@
 # This file will be read by resetprop
 # Example: Change dpi
 # ro.sf.lcd_density=320
+persist.camera.HAL3.enabled=1

--- a/config.sh
+++ b/config.sh
@@ -25,7 +25,7 @@
 AUTOMOUNT=true
 
 # Set to true if you need to load system.prop
-PROPFILE=false
+PROPFILE=true
 
 # Set to true if you need post-fs-data script
 POSTFSDATA=false


### PR DESCRIPTION
Some phones have Camera2 API capabilities, but it is not enabled in their rom.
Since GCam requires Camera2 API anyways, why not make sure that it is enabled in build.prop.